### PR TITLE
Remove browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "ebml parser",
   "main": "lib/ebml.js",
   "module": "lib/ebml.esm.js",
-  "browser": "lib/ebml.iife.js",
   "maintainers": [
     "Jonathan Sifuentes <jayands.dev@gmail.com>",
     "Mark Schmale <masch@masch.it>"


### PR DESCRIPTION
When bundling with webpack or browserify I'm getting the error:

    Uncaught TypeError: ebml.Decoder is not a constructor

Removing the browser field fixes this.
I'm not sure if this breaks something? I don't think the browser field is supposed to reference an IIFE but rather a browser-specific module?